### PR TITLE
Test methode check if user have enterprise v2

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,12 +2,10 @@ name: Playwright Tests
 ## Voir si le déclenchement est approprié pour nos besoins,
 ## les tests se lancent sur toutes les branches à chaque push et pull requests
 on:
-  push:
-    paths:
-      - "front-end/**"
   pull_request:
     paths:
       - "front-end/**"
+      - "playwrightTests/**"
 
 jobs:
   test:

--- a/front-end/projet_application/src/routes/dashboard/+page.svelte
+++ b/front-end/projet_application/src/routes/dashboard/+page.svelte
@@ -158,7 +158,7 @@
             </div>
 
             {#if userHaveEnterprise}
-                <div class="divFlex">
+                <div class="divFlex" id="editEnterprise">
                     <Button
                         onClick={handleEditEnterprise}
                         text="Modifier ton entreprise"

--- a/front-end/projet_application/src/routes/profile/+page.svelte
+++ b/front-end/projet_application/src/routes/profile/+page.svelte
@@ -80,7 +80,7 @@
 
     <div class="Modal">
         {#if userHaveEnterprise}
-            <div class="divFlex">
+            <div class="divFlex" id="editEnterprise">
                 <Button
                     onClick={handleShow}
                     text="Modifier ton entreprise"

--- a/playwrightTests/Helper/Mocks/login.mock.ts
+++ b/playwrightTests/Helper/Mocks/login.mock.ts
@@ -1,0 +1,24 @@
+import { MockConfig } from "../types";
+export const loginMocks = {
+    notFound: {
+        url: '*/**/user/login',
+        response: {
+            status: 404,
+            json: { message: "User not found" }
+        }
+    },
+    success: {
+        url: '*/**/user/login',
+        response: {
+            status: 200,
+            json: {
+                "email": "test@gmail.com",
+                "exp": 1739397843,
+                "active": true,
+                "isModerator": false,
+                "firstName": "test",
+                "lastName": "test"
+            }
+        }
+    }
+} satisfies Record<string, MockConfig>;

--- a/playwrightTests/Helper/Mocks/login.mock.ts
+++ b/playwrightTests/Helper/Mocks/login.mock.ts
@@ -12,12 +12,7 @@ export const loginMocks = {
         response: {
             status: 200,
             json: {
-                "email": "test@gmail.com",
-                "exp": 1739397843,
-                "active": true,
-                "isModerator": false,
-                "firstName": "test",
-                "lastName": "test"
+                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwiZXhwIjoxNzM5NzM5NDY2LCJhY3RpdmUiOnRydWUsImlzTW9kZXJhdG9yIjpmYWxzZSwiZmlyc3ROYW1lIjoiIiwibGFzdE5hbWUiOiIifQ.Fft29KxIDl3KLPrJ_vxQONS1qd4kzor_Fighq7zH3Hk"
             }
         }
     }

--- a/playwrightTests/Helper/Mocks/login.mock.ts
+++ b/playwrightTests/Helper/Mocks/login.mock.ts
@@ -1,4 +1,22 @@
 import { MockConfig } from "../types";
+import jwt from 'jsonwebtoken';
+
+const generateToken = () => {
+    const payload = {
+        email: "test@gmail.com",
+        exp: Math.floor((Date.now() + 30 * 60 * 1000) / 1000), // 30 minutes from now
+        active: true,
+        isModerator: false,
+        firstName: "",
+        lastName: ""
+    };
+
+    // Clé secrète pour les tests
+    const SECRET_KEY = 'cle-secrette-pour-les-tests';
+
+    return jwt.sign(payload, SECRET_KEY);
+};
+
 export const loginMocks = {
     notFound: {
         url: '*/**/user/login',
@@ -12,7 +30,7 @@ export const loginMocks = {
         response: {
             status: 200,
             json: {
-                "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6InRlc3RAZ21haWwuY29tIiwiZXhwIjoxNzM5NzM5NDY2LCJhY3RpdmUiOnRydWUsImlzTW9kZXJhdG9yIjpmYWxzZSwiZmlyc3ROYW1lIjoiIiwibGFzdE5hbWUiOiIifQ.Fft29KxIDl3KLPrJ_vxQONS1qd4kzor_Fighq7zH3Hk"
+                "token": generateToken()
             }
         }
     }

--- a/playwrightTests/package-lock.json
+++ b/playwrightTests/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "concurrently": "^8.2.2",
+        "jsonwebtoken": "^9.0.2",
         "playwright": "^1.44.1"
       },
       "devDependencies": {
@@ -78,6 +79,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -182,6 +188,14 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -238,11 +252,91 @@
         "node": ">=8"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/playwright": {
       "version": "1.44.1",
@@ -296,6 +390,36 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shell-quote": {

--- a/playwrightTests/package.json
+++ b/playwrightTests/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "concurrently": "^8.2.2",
+    "jsonwebtoken": "^9.0.2",
     "playwright": "^1.44.1"
   }
 }

--- a/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
+++ b/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { studyProgramMocks } from '.././Helper/Mocks/studyProgram.mock';
+import { ApiMocker } from '.././Helper/mockApi';
+import { enterpriseMocks } from '../Helper/Mocks/enterprise.mock';
+import { loginMocks } from '../Helper/Mocks/login.mock';
+
+
+
+test.describe('checkIfUserHaveEnterprise', () => {
+
+    test.beforeAll(async ({ page }) => {
+        const apiMocker = new ApiMocker(page);
+        await apiMocker.addMocks([
+            studyProgramMocks.success,
+            loginMocks.success])
+            .apply();
+
+        // se connecte au site (ADDRESSE A CHANGER LORSQUE LE SITE SERA DÉPLOYÉ)
+        await page.goto('http://localhost:5002/login');
+        await page.getByLabel('Nom d\'utilisateur').fill('test@gmail.com');
+        await page.getByLabel('Mot de passe').fill('test');
+        await page.getByRole('button', { name: 'Se connecter' }).click();
+    });
+
+    test('hasEntreprise', async ({ page }) => {
+        const apiMocker = new ApiMocker(page);
+        await apiMocker.addMock(
+            enterpriseMocks.success)
+            .apply();
+
+        await page.goto('http://localhost:5002/dashboard');
+        await page.waitForLoadState('networkidle');
+        if (await page.locator("#cookieBannerOk")) {
+            await page.locator("#cookieBannerOk").click()
+        }
+        await expect(page.locator("#editEnterprise")).toBeVisible();
+        await page.goto('http://localhost:5002/profile');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator("#editEnterprise")).toBeVisible();
+    });
+
+    test('newUserWithoutEnterprise', async ({ page }) => {
+        const apiMocker = new ApiMocker(page);
+        await apiMocker.addMock(
+            enterpriseMocks.notFound)
+            .apply();
+
+        await page.goto('http://localhost:5002/dashboard');
+        await page.waitForLoadState('networkidle');
+        if (await page.locator("#cookieBannerOk")) {
+            await page.locator("#cookieBannerOk").click()
+        }
+
+        await expect(page.locator("#editEnterprise")).toBeHidden();
+        await page.goto('http://localhost:5002/profile');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator("#editEnterprise")).toBeHidden();
+    });
+});

--- a/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
+++ b/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
@@ -15,7 +15,6 @@ test.describe('checkIfUserHaveEnterprise', () => {
             loginMocks.success])
             .apply();
 
-        // se connecte au site (ADDRESSE A CHANGER LORSQUE LE SITE SERA DÉPLOYÉ)
         await page.goto('http://localhost:5002/login');
         await page.waitForLoadState('networkidle');
         await page.getByLabel('Nom d\'utilisateur').fill('test@gmail.com');

--- a/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
+++ b/playwrightTests/tests/test.checkIfUserHaveEnterprise.spec.ts
@@ -8,7 +8,7 @@ import { loginMocks } from '../Helper/Mocks/login.mock';
 
 test.describe('checkIfUserHaveEnterprise', () => {
 
-    test.beforeAll(async ({ page }) => {
+    test.beforeEach(async ({ page }) => {
         const apiMocker = new ApiMocker(page);
         await apiMocker.addMocks([
             studyProgramMocks.success,
@@ -17,6 +17,7 @@ test.describe('checkIfUserHaveEnterprise', () => {
 
         // se connecte au site (ADDRESSE A CHANGER LORSQUE LE SITE SERA DÉPLOYÉ)
         await page.goto('http://localhost:5002/login');
+        await page.waitForLoadState('networkidle');
         await page.getByLabel('Nom d\'utilisateur').fill('test@gmail.com');
         await page.getByLabel('Mot de passe').fill('test');
         await page.getByRole('button', { name: 'Se connecter' }).click();


### PR DESCRIPTION
Les tests passent. Si je compare à ce que nous avions fait mercredi passé, le Mock retourne maintenant un token que j'ai généré en localhost et j'ai aussi changé le beforeAll pour les tests à un beforeEach parce que la méthode studyPrograms faisait une erreur quand le test allait sur la page de profil.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enterprise management enhancements: Users with enterprise accounts now see a consistent option to manage enterprise details on both the dashboard and profile pages.
  - New mock implementation for user login, allowing for improved testing scenarios.
  
- **Bug Fixes**
  - Resolved issues with visibility of enterprise management options based on user account status.

- **Chores**
  - Upgraded internal quality assurance processes and workflows to better support enterprise functionality.
  - Added new dependency for enhanced testing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->