### PR TITLE
fix: définition des variables CSS afin d'obtenir le bon visuel pour l…

### DIFF
--- a/front-end/projet_application/src/styles/global.css
+++ b/front-end/projet_application/src/styles/global.css
@@ -1,3 +1,17 @@
+:root {
+    /* Fix des couleurs du svelte-multiselect : dropdown (ul.options) */
+    --sms-options-bg: #fcfcfc;
+    --sms-options-border: 1px solid #d3d3d3;
+    --sms-options-shadow: 0 0 14pt -3pt rgba(0, 0, 0, 0.2);
+
+    /* Fix des couleurs du svelte-multiselect : le champ lui-même (div.multiselect) */
+    --sms-bg: #fff;
+    --sms-border: 1px solid #d3d3d3;
+
+    /* Fix des couleurs du svelte-multiselect : partagé */
+    --sms-text-color: #222;
+}
+
 body {
     background-color: #1e2634;
     margin: 0px;

--- a/front-end/projet_application/src/styles/global.css
+++ b/front-end/projet_application/src/styles/global.css
@@ -1,4 +1,9 @@
 :root {
+    /* 
+        Fix des couleurs du svelte-multiselect : 
+            Voir ce lien pour tous les détails sur le problème et sa solution :
+            https://github.com/ecoleduweb/EmploiEtudiant/pull/408
+    */
     /* Fix des couleurs du svelte-multiselect : dropdown (ul.options) */
     --sms-options-bg: #fcfcfc;
     --sms-options-border: 1px solid #d3d3d3;


### PR DESCRIPTION
…e svelte-multiselect

> Cette PR et sa discussion sera citée dans le code qu'elle modifie à fins de référence. La case ci-dessous sera cochée une fois ceci fait. Merci de ne pas fusionner d'ici là.
>
> - [x] Cette demande de tirage a été référencée dans le code (une fois cette case cochée) 

closes #407 

> [!TIP]
> Je conseille de lire ma description plus résumée et compréhensible en premier pour vous faire une idée du problème rencontré et sa solution. Si les détails vous intéressent, une version générée par l'IA est disponible plus bas avec beaucoup plus de détails et de technicité. Cependant, sans contexte, la version de l'IA peut être mélangeante au début.

# Description de la PR

> Auteur : William Lévesque

Cette PR crée de nouvelles variables CSS afin de régler un bug où la partie de la CSS (notamment le fond blanc) du `svelte-multiselect` ne fonctionnait pas. Voir l'issue #407 pour les captures d'écran.

En commençant à débugger la problématique, je me suis rendu compte directement que sur ma machine, le problème n'arrivait pas, du moins en `npm run dev`. J'ai alors essayé de faire `npm run build` puis `npm run preview`, et c'est alors que le problème est apparu. Le problème arrivait alors en compilant l'application.

Après d'avoir vérifier qu'une mise à jour des *packages* ne réglait rien, j'ai alors commencé à déboguer le problème avec Claude. Nous avons d'abord vérifié si la CSS était générée; c'était le cas. 

Par la suite, j'ai décider d'aller voir la CSS détecté par le navigateur web, et certains éléments dans la version compilée changeaient, notamment les valeurs que je voulais barrées (voir les annexes 2.1 et 2.2). 

J'ai envoyé ceci à Claude, et il a repéré le problème. La version compilée utilisait un outil de compilation qui convertissait la CSS pour être rétro-compatible vers les plus vieux navigateurs, mais certaines valeurs/variables qu'il utilisait dans son code converti n'existaient pas dans ce qu'il créait. 

Il y avait alors deux solutions : 

- Solution 1 (retenue) : créer manuellement ces variables dans le global.css. Ça règle le problème à la source, garanti de ne rien briser d'autre, mais c'est du travail manuel et il faut le faire à chaque variable manquante, et corriger si le nom de celles-ci changent
- Solution 2 : changer la configuration de compilation afin de ne pas convertir la CSS en version rétro-compatible. Ça règle alors le problème ciblé ici à 100%, dans toutes ses instances. Cependant, ça peut briser la compatibilité avec de plus vieux navigateurs en jouant dans les options de compilation. Considérant que la majorité des utilisateurs ont sûrement un navigateur à jour, ça ne devrait pas être un problème, mais nous avons quand même évitée cette solution pour l'instant.

La solution 1 est choisi puisqu'elle règle directement le problème ciblé sans rien toucher d'autre, mais ce n'est pas un solution parfaite, ni l'est l'autre. La solution 2 pourrait alors être envisagé si le problème devient trop récurrent à différents endroits, ou brise souvent avec les mises-à-jour.

# Description abrégée de l'IA 

> Auteur : Claude.AI
> Révision de William Lévesque

> [!NOTE]
> Cette partie de la documentation a été générée par l'IA [qui a résolu le problème] et optimisée/raccourcie au mieux par moi. J'ai enlevé les parties moins importantes, les hypothèses rejetées et la solution la moins optimale.
>
> Pour voir la conversation originale entière : https://claude.ai/share/586bc679-eb70-45bc-870b-dbf1a5ebfed9  
 
## 1. Le symptôme
 
Le composant `<MultiSelect>` (package `svelte-multiselect`) s'affiche correctement avec `npm run dev`, mais est complètement « nu » après un `npm run build` :
 
- pas de bordure autour du champ,
- pas de fond blanc,
- pas d'ombre portée,
- la liste déroulante s'affiche « à plat » dans le flux de la page au lieu de flotter par-dessus.

Le JavaScript, lui, fonctionne : on peut cliquer, sélectionner, désélectionner. **C'est purement visuel.**
 
<img width="1920" height="567" alt="image" src="https://github.com/user-attachments/assets/922f0661-5beb-4801-acd3-be660dd808be" />

---
 
## 2. La démarche de diagnostic
 
> Voir les annexes en bas pour des captures d'écran de l'inspecteur d'élément.
 
**Hypothèse B — le CSS est présent mais ne s'applique pas.**
Le CSS est bien dans le bundle, mais le navigateur le rejette ou le fait écraser par une autre règle. Ceci pouvait être déterminé à partir des fichiers de build.

Ensuite, en utilisant l'inspecteur du navigateur (onglet *Styles*), on a pu trouver le réel problème. En comparant dev et build sur la même règle :
 
| | dev | build |
|---|---|---|
| `background` | `var(--sms-options-bg, light-dark(#fcfcfc, #222226))` | `var(--sms-options-bg, var(--lightningcss-light, #fcfcfc) var(--lightningcss-dark, #222226))` |
 
Dans le build, quelques propriétés apparaissaient **barrées** dans l'inspecteur : `background`, `color`, `border`, `box-shadow`. Mais pas d'autres comme `position: absolute`, `top`, `width`.
 
Quand une propriété est *barrée* dans l'inspecteur, ça veut dire que le navigateur l'a **vue et rejetée**. Ce n'est pas un CSS manquant — c'est une valeur *invalide*. Et le fait que seules les propriétés de **couleur** soient barrées, alors que celles de **position** passent, montre que le problème est lié aux couleurs, pas au chargement du fichier.
 
---
 
## 3. La cause réelle
 
### La fonction CSS `light-dark()`
 
`svelte-multiselect` utilise une fonction CSS moderne, `light-dark()`, qui permet d'écrire une couleur pour le thème clair et une pour le thème sombre en une seule ligne :
 
```css
background: light-dark(#fcfcfc, #222226);
/* clair → #fcfcfc, sombre → #222226 */
```
 
### Lightning CSS et la « transpilation » du CSS
 
Vite 8 fait passer le CSS du build dans **Lightning CSS**, un optimiseur qui, entre autres, *rétro-compatibilise* le CSS moderne pour les navigateurs plus anciens.
 
Comme `light-dark()` est récent, Lightning CSS le réécrit avec un *polyfill* basé sur des variables CSS :
 
```css
/* écrit par le développeur du package svelte-multiselect */
background: light-dark(#fcfcfc, #222226);
 
/* réécrit par Lightning CSS */
background: var(--lightningcss-light, #fcfcfc) var(--lightningcss-dark, #222226);
```
 
Ce polyfill repose sur une **astuce des variables CSS** : Lightning CSS est censé aussi ajouter, sur `:root`, deux variables « interrupteurs » — l'une vide, l'autre à `initial` — de sorte qu'à l'exécution une seule des deux couleurs survive et que l'autre disparaisse.
 
### Pourquoi ça a cassé
 
**Ces variables `:root` ne sont jamais arrivées jusqu'à la page.** Résultat : les deux `var()` retombent sur leur valeur de repli, et le navigateur reçoit :
 
```css
background: #fcfcfc #222226;   /* deux couleurs pour une seule propriété */
```
 
Ce qui n'a aucun sens. Le navigateur rejette la déclaration, donc on ne voit pas de fond, pas de bordure, pas d'ombre.
 
### Et pourquoi ça marchait en dev ?
 
**Parce qu'en développement, Vite ne fait pas passer le CSS par Lightning CSS.** Le `light-dark()` d'origine est envoyé tel quel au navigateur, qui le comprend nativement. Pas de réécriture → pas de polyfill → pas de bug.

---
 
## 4. Les solutions possibles
 
Trois approches, toutes valides. Le point commun : **empêcher le `var()` cassé d'être consulté**, ou empêcher sa création.
 
### Solution 1 — Définir soi-même les variables `--sms-*` ✅ **RETENUE**
 
Le polyfill cassé n'est utilisé que comme **valeur de repli**. Si la variable principale est définie, le repli n'est jamais évalué :
 
```css
background: var(--sms-options-bg, <repli cassé>);
/*              ^^^^^^^^^^^^^^^^^ si celle-ci existe, le repli est ignoré */
```
 
Il suffit donc de déclarer les variables du package dans le CSS global (`global.css`) :
 
```css
:root {
    /* Boîte extérieure — div.multiselect */
    --sms-bg: #fff;
    --sms-border: 1px solid #d3d3d3;
 
    /* Liste déroulante — ul.options */
    --sms-options-bg: #fcfcfc;
    --sms-options-border: 1px solid #d3d3d3;
    --sms-options-shadow: 0 0 14pt -3pt rgba(0, 0, 0, 0.2);
 
    /* Partagé */
    --sms-text-color: #222;
}
```
 
**Avantages :** aucune config de build, très explicite, et de toute façon on voulait thématiser le composant.
 
**Inconvénient — important :** c'est du **cas par cas**. Chaque `light-dark()` du package qu'on n'a pas anticipé reste cassé (focus, puces sélectionnées, boutons `×` de suppression, surbrillance de l'option active…). Il faut les découvrir un par un à l'inspecteur. Et une future mise à jour du package peut en réintroduire de nouveaux.
 
**Si un nouvel élément du multiselect apparaît sans style après une mise à jour :** c'est presque certainement ça. Inspecter l'élément, repérer la propriété barrée, lire le nom de la variable `--sms-…` dans le `var()`, l'ajouter au bloc `:root`. (et peut-être envisager la solution 2 si ça arrive trop souvent).
 
---
 
### Solution 2 — Relever la cible CSS du build (`cssTarget`)
 
On empêche Lightning CSS de transpiler `light-dark()` en lui disant qu'on ne vise que des navigateurs récents (qui le supportent nativement) :
 
```ts
// vite.config.ts
import { sveltekit } from "@sveltejs/kit/vite"
import { defineConfig } from "vite"
 
export default defineConfig({
    plugins: [sveltekit()],
    build: {
        cssTarget: "chrome123",
    },
})
```
 
Pas de transpilation → pas de polyfill → pas de bug.
 
**Avantages :** **une seule ligne répare toute la classe de bugs** — y compris les cas pas encore découverts, y compris d'autres dépendances qui utiliseraient du CSS moderne.
 
**Inconvénients :** on abandonne le support des vieux navigateurs pour *tout* le CSS du projet (acceptable ici — `light-dark()` est supporté par tous les navigateurs à jour, et le public visé est étudiant/entreprise). C'est aussi un réglage global, moins « visible » qu'un bloc CSS : quelqu'un qui ne connaît pas l'historique ne devinera pas pourquoi il est là.
 
## Annexes

### 2.1 - Inspecteur d'élément de la version compilée

<img width="525" height="791" alt="image" src="https://github.com/user-attachments/assets/8b5320cb-d228-4e93-9051-5364dd3ac7d3" />

### 2.2 - Inspecteur d'élément de la version `npm run dev`

<img width="507" height="655" alt="image" src="https://github.com/user-attachments/assets/ab99849a-206a-44c0-b5df-afa43385c2ff" />
